### PR TITLE
Fix capture features errors

### DIFF
--- a/robot_calibration/include/robot_calibration/capture/chain_manager.h
+++ b/robot_calibration/include/robot_calibration/capture/chain_manager.h
@@ -70,7 +70,7 @@ public:
    * @param nh The node handle, sets namespace for parameters.
    * @param wait_time The time to wait for each action to come up.
    */
-  ChainManager(ros::NodeHandle& nh, double wait_time = 15.0);
+  ChainManager(ros::NodeHandle& nh, double const wait_time = 15.0, bool const mode_auto = true);
 
   /**
    * @brief Send commands to all managed joints. The ChainManager automatically
@@ -119,6 +119,8 @@ private:
   std::vector<boost::shared_ptr<ChainController> > controllers_;
   MoveGroupClientPtr move_group_;
   double velocity_factor_;  // scaling factor to slow down move_group plans
+
+  bool const mode_auto_;
 };
 
 }  // namespace robot_calibration

--- a/robot_calibration/include/robot_calibration/capture/checkerboard_finder.h
+++ b/robot_calibration/include/robot_calibration/capture/checkerboard_finder.h
@@ -39,7 +39,7 @@ class CheckerboardFinder : public FeatureFinder
 {
 public:
   CheckerboardFinder();
-  bool init(const std::string& name, ros::NodeHandle & n);
+  bool init(const std::string& name, ros::NodeHandle & n, bool const head_driver = true);
   bool find(robot_calibration_msgs::CalibrationData * msg);
 
 private:

--- a/robot_calibration/include/robot_calibration/capture/depth_camera.h
+++ b/robot_calibration/include/robot_calibration/capture/depth_camera.h
@@ -35,7 +35,7 @@ public:
   DepthCameraInfoManager() : camera_info_valid_(false) {}
   virtual ~DepthCameraInfoManager() {}
 
-  bool init(ros::NodeHandle& n)
+  bool init(ros::NodeHandle& n, bool const camera_driver = true)
   {
     std::string topic_name;
     n.param<std::string>("camera_info_topic", topic_name, "/head_camera/depth/camera_info");
@@ -46,14 +46,17 @@ public:
                                           this);
 
     // Get parameters of drivers
-    std::string driver_name;
-    n.param<std::string>("camera_driver", driver_name, "/head_camera/driver");
-    if (!n.getParam(driver_name+"/z_offset_mm", z_offset_mm_) ||
-        !n.getParam(driver_name+"/z_scaling", z_scaling_))
+    if (camera_driver)
     {
-      ROS_ERROR("%s is not set, are drivers running?",driver_name.c_str());
-      z_offset_mm_ = 0;
-      z_scaling_ = 1;
+      std::string driver_name;
+      n.param<std::string>("camera_driver", driver_name, "/head_camera/driver");
+      if (!n.getParam(driver_name+"/z_offset_mm", z_offset_mm_) ||
+          !n.getParam(driver_name+"/z_scaling", z_scaling_))
+      {
+        ROS_ERROR("%s is not set, are drivers running?",driver_name.c_str());
+        z_offset_mm_ = 0;
+        z_scaling_ = 1;
+      }
     }
 
     // Wait for camera_info

--- a/robot_calibration/include/robot_calibration/capture/feature_finder_loader.h
+++ b/robot_calibration/include/robot_calibration/capture/feature_finder_loader.h
@@ -46,7 +46,8 @@ public:
   }
 
   bool load(const ros::NodeHandle& nh,
-            FeatureFinderMap& features)
+            FeatureFinderMap& features,
+            bool const head_driver = true)
   {
     // Empty the mapping
     features.clear();
@@ -92,7 +93,7 @@ public:
         ROS_ERROR_STREAM("Failed to load feature: " << type);
         continue;
       }
-      if (!finder->init(name, finder_handle)) {
+      if (!finder->init(name, finder_handle, head_driver)) {
         ROS_ERROR_STREAM("Init of " << name << " failed!");
         continue;
       }

--- a/robot_calibration/include/robot_calibration/capture/led_finder.h
+++ b/robot_calibration/include/robot_calibration/capture/led_finder.h
@@ -87,7 +87,7 @@ class LedFinder : public FeatureFinder
 
 public:
   LedFinder();
-  bool init(const std::string& name, ros::NodeHandle & n);
+  bool init(const std::string& name, ros::NodeHandle & n, bool const head_driver = true);
   bool find(robot_calibration_msgs::CalibrationData * msg);
 
 private:

--- a/robot_calibration/include/robot_calibration/capture/plane_finder.h
+++ b/robot_calibration/include/robot_calibration/capture/plane_finder.h
@@ -31,7 +31,7 @@ class PlaneFinder : public FeatureFinder
 {
 public:
   PlaneFinder();
-  bool init(const std::string& name, ros::NodeHandle & n);
+  bool init(const std::string& name, ros::NodeHandle & n, bool const head_driver = true);
   bool find(robot_calibration_msgs::CalibrationData * msg);
 
 private:

--- a/robot_calibration/include/robot_calibration/capture_features.h
+++ b/robot_calibration/include/robot_calibration/capture_features.h
@@ -40,10 +40,11 @@ std::string get_absolute_directory(const std::string& local_dir);
 * @brief      Creates a map of the available feature finders
 *
 * @param[in]  nh        node handle reference.
+* @param[in]  loader    feature finder loader
 *
 * @return     bool indicating whether the feature finders were loaded 
 */
-std::optional<robot_calibration::FeatureFinderMap> get_feature_finders(const ros::NodeHandle& nh);
+std::optional<robot_calibration::FeatureFinderMap> get_feature_finders(const ros::NodeHandle& nh, robot_calibration::FeatureFinderLoader& loader);
 
 
 // TODO: describe why this is needed.

--- a/robot_calibration/include/robot_calibration/plugins/feature_finder.h
+++ b/robot_calibration/include/robot_calibration/plugins/feature_finder.h
@@ -45,7 +45,8 @@ public:
    *  @returns True/False if the feature finder was able to be initialized
    */
   virtual bool init(const std::string& name,
-                    ros::NodeHandle & nh)
+                    ros::NodeHandle & nh,
+                    bool const head_driver = true)
   {
     name_ = name;
     return true;

--- a/robot_calibration/src/details/capture_features_lib.cpp
+++ b/robot_calibration/src/details/capture_features_lib.cpp
@@ -77,13 +77,11 @@ std::string get_absolute_directory(const std::string& local_dir)
 }
 
 
-std::optional<robot_calibration::FeatureFinderMap> get_feature_finders(const ros::NodeHandle& nh)
+std::optional<robot_calibration::FeatureFinderMap> get_feature_finders(const ros::NodeHandle& nh, robot_calibration::FeatureFinderLoader& feature_finder_loader)
 {
-  robot_calibration::FeatureFinderLoader feature_finder_loader;     // Helper to load the feature finders
   robot_calibration::FeatureFinderMap finders;
 
-// TODO: why won't this unload?
-  if (!feature_finder_loader.load(nh, finders))
+  if (!feature_finder_loader.load(nh, finders, false))
   {
     ROS_FATAL("Unable to load feature finders");
     return {};
@@ -111,7 +109,8 @@ bool run_automatic_capture(ros::NodeHandle nh,
   // TODO
   robot_calibration::ChainManager chain_manager(nh, 0.1);     // Manages kinematic chains
   
-  auto finders = get_feature_finders(nh);        // Holds the available feature finders  
+  robot_calibration::FeatureFinderLoader feature_finder_loader;   
+  auto finders = get_feature_finders(nh, feature_finder_loader);        // Holds the available feature finders  
   if (!finders)
   { 
     ROS_FATAL("the loaded feature finder map is empty.");
@@ -146,14 +145,16 @@ bool run_manual_capture(ros::NodeHandle nh,
   ROS_DEBUG("Running manual capture.");
   bool capture_complete = false;
 
-  robot_calibration::ChainManager chain_manager(nh, 0.1);     // Manages kinematic chains
+  robot_calibration::ChainManager chain_manager(nh, 0.1, false);     // Manages kinematic chains
 
-  auto finders = get_feature_finders(nh);        // Holds the available feature finders  
+  robot_calibration::FeatureFinderLoader feature_finder_loader;     
+  auto finders = get_feature_finders(nh, feature_finder_loader);        // Holds the available feature finders  
   if (!finders)
   { 
     ROS_WARN("feature finders failed to load");
     return false;
   }
+
   auto feature_finder = finders->at(feature);
 
   ros::Publisher pub = nh.advertise<robot_calibration_msgs::CalibrationData>("/calibration_data", 10);

--- a/robot_calibration/src/finders/checkerboard_finder.cpp
+++ b/robot_calibration/src/finders/checkerboard_finder.cpp
@@ -37,7 +37,8 @@ CheckerboardFinder::CheckerboardFinder() :
 }
 
 bool CheckerboardFinder::init(const std::string& name,
-                              ros::NodeHandle & nh)
+                              ros::NodeHandle & nh,
+                              bool const head_driver)
 {
   if (!FeatureFinder::init(name, nh))
     return false;
@@ -92,7 +93,7 @@ bool CheckerboardFinder::init(const std::string& name,
   publisher_ = nh.advertise<sensor_msgs::PointCloud2>(getName() + "_points", 10);
 
   // Setup to get camera depth info
-  if (!depth_camera_manager_.init(nh))
+  if (!depth_camera_manager_.init(nh, head_driver))
   {
     // Error will have been printed by manager
     return false;

--- a/robot_calibration/src/finders/led_finder.cpp
+++ b/robot_calibration/src/finders/led_finder.cpp
@@ -51,7 +51,8 @@ LedFinder::LedFinder() :
 }
 
 bool LedFinder::init(const std::string& name,
-                     ros::NodeHandle& nh)
+                     ros::NodeHandle& nh,
+                     bool const head_driver)
 {
   if (!FeatureFinder::init(name, nh))
     return false;

--- a/robot_calibration/src/finders/plane_finder.cpp
+++ b/robot_calibration/src/finders/plane_finder.cpp
@@ -39,7 +39,8 @@ PlaneFinder::PlaneFinder() :
 }
 
 bool PlaneFinder::init(const std::string& name,
-                       ros::NodeHandle & nh)
+                       ros::NodeHandle & nh,
+                       bool const head_driver)
 {
   if (!FeatureFinder::init(name, nh))
     return false;


### PR DESCRIPTION
Fixes some errors for the capture feature node:

Allows head camera to be not checked
Allows checking for move group to not be checked in manual mode
Puts the feature finder loader in scope